### PR TITLE
performance opt: using copy instead of append

### DIFF
--- a/memlog.go
+++ b/memlog.go
@@ -44,8 +44,8 @@ func (r Record) deepCopy() Record {
 	if r.Metadata.Offset == 0 && r.Metadata.Created.IsZero() {
 		return Record{}
 	}
-
-	dCopy := append([]byte(nil), r.Data...)
+	dCopy := make([]byte, len(r.Data))
+	copy(dCopy, r.Data)
 	return Record{
 		Metadata: Header{
 			Offset:  r.Metadata.Offset,
@@ -139,13 +139,14 @@ func (l *Log) write(ctx context.Context, data []byte) (Offset, error) {
 		return -1, errors.New("no data provided")
 	}
 
-	dcopy := append([]byte(nil), data...)
+	dCopy := make([]byte, len(data))
+	copy(dCopy, data)
 	r := Record{
 		Metadata: Header{
 			Offset:  l.offset,
 			Created: l.clock.Now().UTC(),
 		},
-		Data: dcopy,
+		Data: dCopy,
 	}
 
 	err := l.active.write(ctx, r)


### PR DESCRIPTION
Please see https://gist.github.com/spongecaptain/c5eedde03caaaa5f3de0331a50d24baa

Using copy instead of append brings performance improvements.

Original version benchmark test result:

```
$ go test -v -run=none -bench=. -cpu 1,2,4,8,16 -benchmem

goos: darwin
goarch: arm64
pkg: github.com/embano1/memlog
BenchmarkLog_write
BenchmarkLog_write              12658945                83.79 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-2            14599183                81.88 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-4            14565168                81.85 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-8            14652230                80.89 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-16           14582964                81.61 ns/op           89 B/op          1 allocs/op
BenchmarkLog_read
BenchmarkLog_read               23078679                51.61 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-2             23851464                49.38 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-4             23998719                50.11 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-8             23799724                50.11 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-16            23617048                49.77 ns/op           32 B/op          1 allocs/op
PASS
ok      github.com/embano1/memlog       12.563s
```

Using copy version:

```
$ go test -v -run=none -bench=. -cpu 1,2,4,8,16 -benchmem

goos: darwin
goarch: arm64
pkg: github.com/embano1/memlog
BenchmarkLog_write
BenchmarkLog_write              15381063                78.47 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-2            15534843                77.78 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-4            15860680                75.88 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-8            15975698                75.16 ns/op           89 B/op          1 allocs/op
BenchmarkLog_write-16           15493441                76.15 ns/op           89 B/op          1 allocs/op
BenchmarkLog_read
BenchmarkLog_read               25497036                47.53 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-2             26456144                45.67 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-4             25824014                45.50 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-8             26311268                45.73 ns/op           32 B/op          1 allocs/op
BenchmarkLog_read-16            26083293                45.62 ns/op           32 B/op          1 allocs/op
PASS
ok      github.com/embano1/memlog       13.762s
```
