### PR TITLE
Sharding example uses `len(keys)`

### DIFF
--- a/sharded/example_sharder_test.go
+++ b/sharded/example_sharder_test.go
@@ -17,7 +17,7 @@ func Example_sharder() {
 	ks := sharded.NewKeySharder(keys)
 
 	opts := []sharded.Option{
-		sharded.WithNumShards(2), // must be >=len(keys)
+		sharded.WithNumShards(uint(len(keys))), // must be >=len(keys)
 		sharded.WithSharder(ks),
 	}
 	l, err := sharded.New(ctx, opts...)


### PR DESCRIPTION
Closes: #40
Signed-off-by: Michael Gasch <mgasch@vmware.com>